### PR TITLE
Allow building the VS Code extension with Nix

### DIFF
--- a/crates/adroit/src/compile.rs
+++ b/crates/adroit/src/compile.rs
@@ -22,7 +22,7 @@ pub struct FullModule<'a> {
 }
 
 pub trait Importer {
-    fn import(&self, id: typecheck::ImportId) -> FullModule;
+    fn import(&self, id: typecheck::ImportId) -> FullModule<'_>;
 }
 
 #[derive(Clone, Debug)]
@@ -32,7 +32,7 @@ pub struct GraphImporter<'a> {
 }
 
 impl Importer for GraphImporter<'_> {
-    fn import(&self, id: ImportId) -> FullModule {
+    fn import(&self, id: ImportId) -> FullModule<'_> {
         match &self.graph.get(&self.uris[id.to_usize()]).data {
             Data::Analyzed { syn, sem, errs } => {
                 assert!(errs.is_empty());
@@ -83,18 +83,18 @@ impl<'a, I: Clone + Importer> Printer<'a, I> {
         expr_range(self.full.tokens, self.full.tree, id).unwrap()
     }
 
-    pub fn ty(&self, id: typecheck::TypeId) -> Type<I> {
+    pub fn ty(&self, id: typecheck::TypeId) -> Type<'_, I> {
         Type {
             printer: self.clone(),
             id,
         }
     }
 
-    fn param_ty(&self, id: parse::ParamId) -> Type<I> {
+    fn param_ty(&self, id: parse::ParamId) -> Type<'_, I> {
         self.ty(self.full.module.val(self.full.module.param(id)).ty)
     }
 
-    fn expr_ty(&self, id: parse::ExprId) -> Type<I> {
+    fn expr_ty(&self, id: parse::ExprId) -> Type<'_, I> {
         self.ty(self.full.module.val(self.full.module.expr(id)).ty)
     }
 

--- a/crates/adroit/src/typecheck/mod.rs
+++ b/crates/adroit/src/typecheck/mod.rs
@@ -87,25 +87,6 @@ impl Id for UnknownId {
 
 #[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
 #[serde(transparent)]
-pub struct VarId {
-    pub index: u32,
-}
-
-impl Id for VarId {
-    fn from_usize(n: usize) -> Option<Self> {
-        match n.try_into() {
-            Ok(index) => Some(Self { index }),
-            Err(_) => None,
-        }
-    }
-
-    fn to_usize(self) -> usize {
-        u32_to_usize(self.index)
-    }
-}
-
-#[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
-#[serde(transparent)]
 pub struct ValId {
     pub index: u32,
 }

--- a/flake.lock
+++ b/flake.lock
@@ -8,11 +8,11 @@
         "rust-analyzer-src": "rust-analyzer-src"
       },
       "locked": {
-        "lastModified": 1745303921,
-        "narHash": "sha256-zYucemS2QvJUR5GKJ/u3eZAoe82AKhcxMtNVZDERXsw=",
+        "lastModified": 1755585599,
+        "narHash": "sha256-tl/0cnsqB/Yt7DbaGMel2RLa7QG5elA8lkaOXli6VdY=",
         "owner": "nix-community",
         "repo": "fenix",
-        "rev": "14850d5984f3696a2972f85f19085e5fb46daa95",
+        "rev": "6ed03ef4c8ec36d193c18e06b9ecddde78fb7e42",
         "type": "github"
       },
       "original": {
@@ -41,11 +41,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1744868846,
-        "narHash": "sha256-5RJTdUHDmj12Qsv7XOhuospjAjATNiTMElplWnJE9Hs=",
+        "lastModified": 1756381814,
+        "narHash": "sha256-tzo7YvAsGlzo4WiIHT0ooR59VHu+aKRQdHk7sIyoia4=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "ebe4301cbd8f81c4f8d3244b3632338bbeb6d49c",
+        "rev": "aca2499b79170038df0dbaec8bf2f689b506ad32",
         "type": "github"
       },
       "original": {
@@ -65,11 +65,11 @@
     "rust-analyzer-src": {
       "flake": false,
       "locked": {
-        "lastModified": 1745247864,
-        "narHash": "sha256-QA1Ba8Flz5K+0GbG03HwiX9t46mh/jjKgwavbuKtwMg=",
+        "lastModified": 1755504847,
+        "narHash": "sha256-VX0B9hwhJypCGqncVVLC+SmeMVd/GAYbJZ0MiiUn2Pk=",
         "owner": "rust-lang",
         "repo": "rust-analyzer",
-        "rev": "31dbec70c68e97060916d4754c687a3e93c2440f",
+        "rev": "a905e3b21b144d77e1b304e49f3264f6f8d4db75",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -21,16 +21,14 @@
         pkgs = import nixpkgs { inherit system; };
       in
       {
-        devShell =
-          with pkgs;
-          mkShell {
-            buildInputs = [
-              bun
-              nixfmt-rfc-style
-
-              (fenix.packages.${system}.stable.toolchain)
-            ];
-          };
+        devShell = pkgs.mkShell {
+          buildInputs = [
+            pkgs.bun
+            pkgs.nixfmt
+            pkgs.nodejs # Used by vsce.
+            (fenix.packages.${system}.stable.toolchain)
+          ];
+        };
       }
     );
 }


### PR DESCRIPTION
`vsce` tries to run `npm -v`, so it needs Node.